### PR TITLE
User requests[security] instead of requests

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,7 +17,7 @@ MyEnv/bin/easy_install pyrobase
 MyEnv/bin/easy_install pyrocore
 MyEnv/bin/easy_install --upgrade sqlalchemy
 MyEnv/bin/easy_install flask
-MyEnv/bin/easy_install requests
+MyEnv/bin/easy_install requests[security]
 MyEnv/bin/easy_install watchdog
 MyEnv/bin/pyroadmin --create-config
 


### PR DESCRIPTION
This will get rid of the error "/requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning." in requests 2.6.0. Please note that this is not required for python-2.7.9+
